### PR TITLE
Adding new BotDefintion fields: default_subscriptions and data_encoding

### DIFF
--- a/offchain-example/Cargo.toml
+++ b/offchain-example/Cargo.toml
@@ -16,8 +16,8 @@ toml = "0.8.20"
 tower-http = { version = "0.6.2", features = ["cors", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-oc_bots_sdk = { git = "https://github.com/open-chat-labs/open-chat-bots.git", rev = "874641f68a037476f645f41934716f8547289d56" }
-oc_bots_sdk_offchain = { git = "https://github.com/open-chat-labs/open-chat-bots.git", rev = "874641f68a037476f645f41934716f8547289d56" }
+oc_bots_sdk = { git = "https://github.com/open-chat-labs/open-chat-bots.git", branch = "main" }
+oc_bots_sdk_offchain = { git = "https://github.com/open-chat-labs/open-chat-bots.git", branch = "main" }
 reqwest = { version = "0.11", features = ["json"] }
 
 [profile.release]

--- a/offchain-example/src/main.rs
+++ b/offchain-example/src/main.rs
@@ -91,6 +91,8 @@ async fn bot_definition(State(state): State<Arc<AppState>>) -> (StatusCode, Head
         description: "A simple echo bot that repeats your messages".to_string(),
         commands,
         autonomous_config: None,
+        default_subscriptions: None,
+        data_encoding: None,
     };
     
     let mut headers = HeaderMap::new();

--- a/onchain-example/src/router/definition.rs
+++ b/onchain-example/src/router/definition.rs
@@ -11,6 +11,8 @@ pub async fn get(_request: HttpRequest) -> HttpResponse {
                     .to_string(),
             commands: commands::definitions(),
             autonomous_config: None,
+            default_subscriptions: None,
+            data_encoding: None,
         },
     )
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
     "create",
     "cli",
     "internet computer",
-    "Internet Computer",
     "ICP",
     "OpenChat",
     "OpenChat Bot",
     "OpenChat Bot Template",
-    "OpenChat Bot Creator",
     "OpenChat Bot Generator"
   ],
   "author": "ICP HUBS DevRels Syndicate",


### PR DESCRIPTION
Fixing offchain & onchain example templates to have access to the ``default_subscriptions`` and ``data_encoding`` fields in the ``BotDefinition`` struct